### PR TITLE
Enable signing of transactions that have more than one input.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ java-client
 
 Java SDK for BlockCypher
 
+May requires the following dependencies to be added to your project:
+- org.glassfish.jersey.core -> jersey-client 2.9
+- javax.ws.rs -> javax.ws.rs-api 2.0.1
+- com.madgag -> sc-light-jdk15on 1.47.0.3
+
 <!--Maven
 -----
 Add this to your POM:


### PR DESCRIPTION
The code only previously worked for transactions with one input.

This pull requests adds three new public methods (and leaves the three existing ones in place for backwards compatibility).

There are no huge changes, just introduces a loop to sign each of the toSign transactions with one of a supplied list of private keys.